### PR TITLE
Add Pop OS Kubernetes deployment with GitHub Actions

### DIFF
--- a/.github/workflows/pop-os-1-deploy.yml
+++ b/.github/workflows/pop-os-1-deploy.yml
@@ -1,0 +1,315 @@
+# This workflow will deploy the Solace Service to a self-hosted Kubernetes cluster on Pop OS
+#
+# To configure this workflow:
+#
+# 1. Set up a self-hosted GitHub runner on your Pop OS server
+#    - Follow instructions at: https://docs.github.com/en/actions/hosting-your-own-runners
+#    - Tag the runner with 'pop-os-1' label
+#
+# 2. Ensure the runner has access to:
+#    - Docker
+#    - kubectl
+#    - Java 21 (for building the application)
+#    - A running Kubernetes cluster (MicroK8s, K3s, or Minikube)
+#    - Proper permissions to create/modify resources in the cluster
+
+name: Deploy to Pop OS Kubernetes pop-os-1
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "src/**"
+      - "build.gradle"
+      - "kubernetes-pop-os/**"
+      - ".github/workflows/pop-os-1-deploy.yml"
+  workflow_dispatch:
+    inputs:
+      solace_enabled:
+        description: 'Enable Solace broker connection'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+      azure_storage_enabled:
+        description: 'Enable Azure Blob Storage'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+env:
+  SOLACE_ENABLED: ${{ github.event.inputs.solace_enabled || 'false' }}
+  AZURE_STORAGE_ENABLED: ${{ github.event.inputs.azure_storage_enabled || 'false' }}
+  MANIFEST_DIR: "kubernetes-pop-os"
+
+jobs:
+  deploy:
+    name: Deploy to Pop OS Kubernetes pop-os-1
+    # Ensure this job only runs on runners with the 'pop-os-1' label
+    # This ensures the workflow only runs on the designated Pop OS server
+    runs-on: [self-hosted, pop-os-1]
+
+    steps:
+      # Checks out the repository
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Verify Kubernetes connection
+      - name: Verify Kubernetes connection
+        run: |
+          echo "Verifying Kubernetes connection..."
+          if kubectl get nodes &>/dev/null; then
+            echo "Kubernetes connection successful."
+            # Get cluster info
+            echo "Cluster information:"
+            kubectl cluster-info
+          else
+            echo "Cannot connect to Kubernetes. Please check your Kubernetes installation."
+          fi
+
+      # Start Minikube if it's not running
+      - name: Start Minikube
+        run: |
+          echo "Checking if Minikube is running..."
+          if command -v minikube &> /dev/null; then
+            MINIKUBE_RUNNING=false
+
+            # Check if minikube status reports running
+            if minikube status | grep -q "Running"; then
+              echo "Minikube status reports running. Verifying connectivity..."
+
+              # Update kubectl config from minikube
+              minikube update-context
+
+              # Try to connect to the cluster
+              if kubectl cluster-info &>/dev/null; then
+                echo "✅ Minikube is running and accessible."
+                MINIKUBE_RUNNING=true
+              else
+                echo "⚠️ Minikube reports running but cluster is not accessible. Restarting..."
+                minikube delete
+                minikube start
+                MINIKUBE_RUNNING=true
+              fi
+            else
+              echo "Minikube is not running. Starting Minikube..."
+              minikube start
+              MINIKUBE_RUNNING=true
+            fi
+
+            # Enable required addons after start/restart
+            if [ "$MINIKUBE_RUNNING" = true ]; then
+              echo "Ensuring required Minikube addons are enabled..."
+              minikube addons enable storage-provisioner
+              minikube addons enable default-storageclass
+
+              # Update kubectl config to ensure we have the latest cluster info
+              minikube update-context
+
+              # Ensure kubectl is using minikube context
+              echo "Setting kubectl context to minikube..."
+              kubectl config use-context minikube
+
+              # Verify connection to minikube cluster
+              echo "Verifying connection to Minikube cluster..."
+              kubectl cluster-info
+              echo "✅ Minikube is ready."
+            fi
+          else
+            echo "Minikube is not installed. Will rely on existing Kubernetes setup."
+          fi
+
+      # Build the Spring Boot application
+      - name: Build Spring Boot application
+        run: |
+          echo "Building Spring Boot application with Gradle..."
+          ./gradlew clean build -x test
+
+          # Verify JAR was created
+          JAR_FILE=$(ls build/libs/*.jar | head -1)
+          if [ -z "$JAR_FILE" ]; then
+            echo "❌ Build failed - JAR file not found"
+            exit 1
+          fi
+
+          echo "✅ JAR file built: $JAR_FILE"
+
+      # Build Docker image in Minikube's Docker daemon
+      - name: Build Docker image
+        working-directory: ${{ env.MANIFEST_DIR }}
+        run: |
+          echo "Building Docker image for Solace Service..."
+
+          # If using Minikube, use its Docker daemon
+          if command -v minikube &> /dev/null && minikube status | grep -q "Running"; then
+            echo "Using Minikube's Docker daemon..."
+            eval $(minikube docker-env)
+          fi
+
+          # Build the image
+          ./build-image.sh
+
+          echo "✅ Docker image built successfully"
+
+      # Update ConfigMap with workflow inputs
+      - name: Update ConfigMap
+        working-directory: ${{ env.MANIFEST_DIR }}
+        run: |
+          # Update Azure Storage setting
+          sed -i "s|AZURE_STORAGE_ENABLED: \".*\"|AZURE_STORAGE_ENABLED: \"${{ env.AZURE_STORAGE_ENABLED }}\"|g" 01-configmap.yaml
+
+          echo "ConfigMap updated with AZURE_STORAGE_ENABLED=${{ env.AZURE_STORAGE_ENABLED }}"
+
+      # Create or update Kubernetes secrets
+      - name: Create Kubernetes secrets
+        run: |
+          kubectl create namespace solace-service --dry-run=client -o yaml | kubectl apply -f -
+
+          # Create solace-service-secret
+          kubectl create secret generic solace-service-secret \
+            --from-literal=SOLACE_USERNAME="default" \
+            --from-literal=SOLACE_PASSWORD="default" \
+            --from-literal=AZURE_STORAGE_CONNECTION_STRING='${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}' \
+            -n solace-service --dry-run=client -o yaml | kubectl apply -f -
+
+          echo "✅ Secrets created/updated"
+
+      # Check for existing deployment
+      - name: Check for existing deployment
+        run: |
+          if kubectl get namespace solace-service &>/dev/null; then
+            echo "Solace service namespace already exists. Will update existing deployment."
+          else
+            echo "No existing Solace service deployment found. Will create new deployment."
+          fi
+
+      # Deploy to Kubernetes
+      - name: Deploy to Kubernetes
+        working-directory: ${{ env.MANIFEST_DIR }}
+        run: |
+          echo "Deploying to Kubernetes cluster..."
+
+          # Apply manifests
+          kubectl apply -f 00-namespace.yaml
+          kubectl apply -f 01-configmap.yaml
+          kubectl apply -f 02-secrets.yaml
+          kubectl apply -f 03-deployment.yaml
+          kubectl apply -f 04-service.yaml
+
+          echo "✅ Manifests applied"
+
+      # Force a rolling restart of the deployment
+      - name: Force rolling restart
+        run: |
+          echo "Forcing a rolling restart of the Solace service deployment..."
+          # This will cause all pods to be recreated with the latest image
+          kubectl rollout restart deployment/solace-service -n solace-service
+          # Wait for the rollout to complete
+          kubectl rollout status deployment/solace-service -n solace-service --timeout=300s
+
+      # Display service information
+      - name: Display service information
+        run: |
+          echo "Waiting for services to be ready..."
+          sleep 10
+
+          # Get service details
+          echo "Solace Service Details:"
+          kubectl get svc -n solace-service
+
+          # Get NodePort
+          NODE_PORT=$(kubectl get svc solace-service -n solace-service -o jsonpath='{.spec.ports[0].nodePort}')
+
+          if [ -n "$NODE_PORT" ]; then
+            # Check if we're using Minikube
+            if command -v minikube &> /dev/null && minikube status | grep -q "Running"; then
+              MINIKUBE_IP=$(minikube ip)
+              echo "Solace service is available at http://$MINIKUBE_IP:$NODE_PORT"
+            else
+              echo "Solace service is available at http://localhost:$NODE_PORT"
+            fi
+          else
+            # Try ClusterIP if NodePort isn't available
+            CLUSTER_IP=$(kubectl get svc solace-service -n solace-service -o jsonpath='{.spec.clusterIP}')
+            PORT=$(kubectl get svc solace-service -n solace-service -o jsonpath='{.spec.ports[0].port}')
+
+            if [ -n "$CLUSTER_IP" ] && [ -n "$PORT" ]; then
+              echo "Solace service is available within the cluster at http://$CLUSTER_IP:$PORT"
+              echo "Use port forwarding to access: kubectl port-forward svc/solace-service -n solace-service $PORT:$PORT"
+            else
+              echo "Could not determine Solace service address. Check deployment manually."
+            fi
+          fi
+
+          # List all pods
+          echo "All pods:"
+          kubectl get pods -n solace-service -o wide
+
+      # Verify deployment health
+      - name: Verify deployment health
+        run: |
+          echo "Verifying deployment health..."
+
+          # Wait a bit for pods to stabilize
+          sleep 15
+
+          # Check if all pods are running
+          TOTAL_PODS=$(kubectl get pods -n solace-service --no-headers 2>/dev/null | wc -l)
+          RUNNING_PODS=$(kubectl get pods -n solace-service --no-headers 2>/dev/null | grep "Running" | wc -l)
+
+          echo "Total pods: $TOTAL_PODS, Running pods: $RUNNING_PODS"
+
+          if [ "$RUNNING_PODS" -eq "$TOTAL_PODS" ] && [ "$TOTAL_PODS" -gt 0 ]; then
+            echo "✅ All pods are running. Deployment successful!"
+          else
+            echo "⚠️ Warning: Not all pods are running. Check the logs for more details."
+
+            # List non-running pods
+            echo "Non-running pods:"
+            kubectl get pods -n solace-service --field-selector status.phase!=Running
+
+            # Show logs for the Solace service pod if it exists
+            if kubectl get pods -n solace-service -l app=solace-service &>/dev/null; then
+              echo "Solace service logs:"
+              kubectl logs -n solace-service -l app=solace-service --tail=50 || true
+            fi
+          fi
+
+      # Test the deployment
+      - name: Test deployment
+        run: |
+          echo "Testing the deployment..."
+
+          # Get the NodePort
+          NODE_PORT=$(kubectl get svc solace-service -n solace-service -o jsonpath='{.spec.ports[0].nodePort}')
+
+          if [ -n "$NODE_PORT" ]; then
+            # Determine the service URL
+            if command -v minikube &> /dev/null && minikube status | grep -q "Running"; then
+              MINIKUBE_IP=$(minikube ip)
+              SERVICE_URL="http://$MINIKUBE_IP:$NODE_PORT"
+            else
+              SERVICE_URL="http://localhost:$NODE_PORT"
+            fi
+
+            echo "Testing health endpoint at: $SERVICE_URL/actuator/health"
+
+            # Wait for the service to be ready
+            for i in {1..30}; do
+              if curl -f -s "$SERVICE_URL/actuator/health" > /dev/null; then
+                echo "✅ Health check passed!"
+                curl -s "$SERVICE_URL/actuator/health" | head -20
+                break
+              else
+                echo "Waiting for service to be ready... ($i/30)"
+                sleep 5
+              fi
+            done
+          else
+            echo "⚠️ NodePort not found. Skipping health check."
+          fi

--- a/README.md
+++ b/README.md
@@ -166,6 +166,27 @@ Deploy to Azure AKS with full Azure integration:
 
 See [AKS Deployment Guide](AKS-DEPLOYMENT-GUIDE.md) for complete instructions.
 
+### Pop OS / Local Kubernetes (Minikube, MicroK8s, K3s)
+
+Deploy to a local Kubernetes cluster on Pop OS or similar Linux distributions:
+
+```bash
+# Automated deployment
+cd kubernetes-pop-os
+./deploy-local.sh
+
+# Or use GitHub Actions for automated deployment to pop-os-1
+# Configure self-hosted runner with 'pop-os-1' label
+```
+
+**Features:**
+- Automated local Kubernetes deployment
+- Support for Minikube, MicroK8s, and K3s
+- GitHub Actions integration for CI/CD
+- NodePort service for easy local access
+
+See [kubernetes-pop-os/README.md](kubernetes-pop-os/README.md) for complete instructions.
+
 ### Generic Kubernetes (EKS, GKE, etc.)
 
 Deploy to any Kubernetes cluster:

--- a/kubernetes-pop-os/00-namespace.yaml
+++ b/kubernetes-pop-os/00-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: solace-service
+  labels:
+    name: solace-service
+    environment: development

--- a/kubernetes-pop-os/01-configmap.yaml
+++ b/kubernetes-pop-os/01-configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: solace-service-config
+  namespace: solace-service
+data:
+  # Spring Boot Application settings
+  SERVER_PORT: "8080"
+  SPRING_PROFILES_ACTIVE: "local"
+
+  # Solace settings (can be overridden by secrets)
+  SOLACE_HOST: "tcp://solace-broker:55555"
+  SOLACE_VPN: "default"
+  SOLACE_QUEUE_NAME: "test.queue"
+
+  # Azure Storage settings
+  AZURE_STORAGE_ENABLED: "false"
+  AZURE_STORAGE_CONTAINER_NAME: "solace-messages"
+
+  # Logging
+  LOGGING_LEVEL_ROOT: "INFO"
+  LOGGING_LEVEL_COM_EXAMPLE: "DEBUG"

--- a/kubernetes-pop-os/02-secrets.yaml
+++ b/kubernetes-pop-os/02-secrets.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: solace-service-secret
+  namespace: solace-service
+type: Opaque
+stringData:
+  # Solace credentials
+  SOLACE_USERNAME: "default"
+  SOLACE_PASSWORD: "default"
+
+  # Azure Storage credentials (if needed)
+  AZURE_STORAGE_CONNECTION_STRING: ""

--- a/kubernetes-pop-os/03-deployment.yaml
+++ b/kubernetes-pop-os/03-deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: solace-service
+  namespace: solace-service
+  labels:
+    app: solace-service
+    version: v1
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: solace-service
+  template:
+    metadata:
+      labels:
+        app: solace-service
+        version: v1
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/actuator/prometheus"
+    spec:
+      containers:
+      - name: solace-service
+        image: solace-service:local
+        imagePullPolicy: Never  # Use locally built image in Minikube
+
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+
+        # Environment variables from ConfigMap and Secret
+        envFrom:
+        - configMapRef:
+            name: solace-service-config
+        - secretRef:
+            name: solace-service-secret
+
+        # Resource limits and requests
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "1000m"
+
+        # Liveness probe - checks if the app is running
+        livenessProbe:
+          httpGet:
+            path: /actuator/health/liveness
+            port: http
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+
+        # Readiness probe - checks if the app is ready to serve traffic
+        readinessProbe:
+          httpGet:
+            path: /actuator/health/readiness
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+
+        # Startup probe - protects slow starting containers
+        startupProbe:
+          httpGet:
+            path: /actuator/health/liveness
+            port: http
+          initialDelaySeconds: 0
+          periodSeconds: 10
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 18  # 180 seconds to start

--- a/kubernetes-pop-os/04-service.yaml
+++ b/kubernetes-pop-os/04-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: solace-service
+  namespace: solace-service
+  labels:
+    app: solace-service
+spec:
+  type: NodePort
+  selector:
+    app: solace-service
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+    nodePort: 30080  # External access port

--- a/kubernetes-pop-os/Dockerfile.local
+++ b/kubernetes-pop-os/Dockerfile.local
@@ -1,0 +1,18 @@
+FROM eclipse-temurin:21-jre-jammy
+
+WORKDIR /app
+
+# Copy the JAR file
+COPY build/libs/*.jar app.jar
+
+# Create a non-root user
+RUN groupadd -r appuser && useradd -r -g appuser appuser && \
+    chown -R appuser:appuser /app
+
+USER appuser
+
+# Expose the application port
+EXPOSE 8080
+
+# Run the application
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/kubernetes-pop-os/README.md
+++ b/kubernetes-pop-os/README.md
@@ -1,0 +1,229 @@
+# Kubernetes Deployment for Pop OS / Local Development
+
+This directory contains Kubernetes manifests and deployment scripts for running the Solace Service on a local Kubernetes cluster (Minikube, MicroK8s, or K3s) on Pop OS Linux.
+
+## Prerequisites
+
+1. **Kubernetes** - One of the following:
+   - Minikube: `curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && sudo install minikube-linux-amd64 /usr/local/bin/minikube`
+   - MicroK8s: `sudo snap install microk8s --classic`
+   - K3s: `curl -sfL https://get.k3s.io | sh -`
+
+2. **kubectl**: `sudo apt install kubectl`
+
+3. **Docker**: Required for building images
+   - `sudo apt install docker.io`
+   - Add your user to docker group: `sudo usermod -aG docker $USER`
+
+4. **Java 21**: For building the application
+   - `sudo apt install openjdk-21-jdk`
+
+## Quick Start
+
+### Option 1: Automated Deployment
+
+Run the deployment script from the `kubernetes-pop-os` directory:
+
+```bash
+cd kubernetes-pop-os
+./deploy-local.sh
+```
+
+This script will:
+1. Detect your Kubernetes provider (Minikube, MicroK8s, or K3s)
+2. Build the Spring Boot application
+3. Build the Docker image
+4. Deploy to Kubernetes
+5. Display service access information
+
+### Option 2: Manual Deployment
+
+1. **Build the application**:
+```bash
+cd ..
+./gradlew clean build -x test
+```
+
+2. **Build the Docker image**:
+```bash
+cd kubernetes-pop-os
+./build-image.sh
+```
+
+3. **Deploy to Kubernetes**:
+```bash
+kubectl apply -f 00-namespace.yaml
+kubectl apply -f 01-configmap.yaml
+kubectl apply -f 02-secrets.yaml
+kubectl apply -f 03-deployment.yaml
+kubectl apply -f 04-service.yaml
+```
+
+4. **Wait for deployment**:
+```bash
+kubectl -n solace-service rollout status deployment/solace-service
+```
+
+## Accessing the Service
+
+### Via NodePort (default)
+
+The service is exposed on NodePort 30080:
+
+- **Minikube**: `http://$(minikube ip):30080`
+- **MicroK8s/K3s**: `http://localhost:30080`
+
+Or use Minikube's service command:
+```bash
+minikube service solace-service -n solace-service
+```
+
+### Via Port Forwarding
+
+```bash
+kubectl port-forward -n solace-service svc/solace-service 8080:8080
+```
+
+Then access at: `http://localhost:8080`
+
+## Testing the Service
+
+```bash
+# Health check
+curl http://localhost:30080/actuator/health
+
+# Send a test message
+curl -X POST http://localhost:30080/api/messages/send \
+  -H 'Content-Type: application/json' \
+  -d '{"content":"Test message","destination":"test.queue"}'
+```
+
+## Configuration
+
+### Environment Variables
+
+Configuration is managed through:
+- **ConfigMap** (`01-configmap.yaml`): Non-sensitive configuration
+- **Secret** (`02-secrets.yaml`): Sensitive data (passwords, credentials)
+
+To update configuration:
+1. Edit the YAML files
+2. Apply changes: `kubectl apply -f 01-configmap.yaml`
+3. Restart the deployment: `kubectl rollout restart -n solace-service deployment/solace-service`
+
+### Connecting to Solace
+
+By default, the service expects a Solace broker at `tcp://solace-broker:55555`. To use an external broker:
+
+1. Update `01-configmap.yaml`:
+```yaml
+SOLACE_HOST: "tcp://your-broker:55555"
+SOLACE_VPN: "your-vpn"
+```
+
+2. Update `02-secrets.yaml`:
+```yaml
+SOLACE_USERNAME: "your-username"
+SOLACE_PASSWORD: "your-password"
+```
+
+3. Apply changes and restart.
+
+## Monitoring and Debugging
+
+### View Pods
+```bash
+kubectl get pods -n solace-service
+```
+
+### View Logs
+```bash
+# Follow logs
+kubectl logs -n solace-service -l app=solace-service -f
+
+# View logs from specific pod
+kubectl logs -n solace-service <pod-name>
+```
+
+### Describe Pod
+```bash
+kubectl describe pod -n solace-service <pod-name>
+```
+
+### Execute Commands in Pod
+```bash
+kubectl exec -it -n solace-service <pod-name> -- /bin/bash
+```
+
+### View Events
+```bash
+kubectl get events -n solace-service --sort-by='.lastTimestamp'
+```
+
+## Files
+
+- `00-namespace.yaml`: Creates the `solace-service` namespace
+- `01-configmap.yaml`: Application configuration
+- `02-secrets.yaml`: Sensitive credentials
+- `03-deployment.yaml`: Main application deployment
+- `04-service.yaml`: Service for exposing the application
+- `Dockerfile.local`: Docker image definition
+- `build-image.sh`: Script to build Docker image
+- `deploy-local.sh`: Automated deployment script
+
+## GitHub Actions
+
+The service can be automatically deployed via GitHub Actions. See the workflow file at `.github/workflows/pop-os-1-deploy.yml`.
+
+The workflow triggers on:
+- Push to `main` branch
+- Manual workflow dispatch
+
+## Troubleshooting
+
+### Image Pull Errors
+
+If you see `ImagePullBackOff` or `ErrImagePull`:
+
+1. Ensure the image was built with Minikube's Docker daemon:
+```bash
+eval $(minikube docker-env)
+./build-image.sh
+```
+
+2. Check that `imagePullPolicy: Never` is set in the deployment
+
+### Deployment Not Ready
+
+1. Check pod status:
+```bash
+kubectl get pods -n solace-service
+kubectl describe pod -n solace-service <pod-name>
+```
+
+2. Check logs for errors:
+```bash
+kubectl logs -n solace-service <pod-name>
+```
+
+### Port Already in Use
+
+If NodePort 30080 is already in use, edit `04-service.yaml` and change the `nodePort` value.
+
+## Cleanup
+
+To remove the deployment:
+
+```bash
+kubectl delete namespace solace-service
+```
+
+Or delete individual resources:
+
+```bash
+kubectl delete -f 04-service.yaml
+kubectl delete -f 03-deployment.yaml
+kubectl delete -f 02-secrets.yaml
+kubectl delete -f 01-configmap.yaml
+kubectl delete -f 00-namespace.yaml
+```

--- a/kubernetes-pop-os/build-image.sh
+++ b/kubernetes-pop-os/build-image.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Building Solace Service Docker image for local deployment${NC}"
+
+# Get the project root directory (parent of kubernetes-pop-os)
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Build the application
+echo -e "${YELLOW}Building application with Gradle...${NC}"
+./gradlew clean build -x test
+
+# Check if build was successful
+if [ ! -f build/libs/*.jar ]; then
+    echo -e "${RED}Build failed - JAR file not found${NC}"
+    exit 1
+fi
+
+# Get JAR file name
+JAR_FILE=$(ls build/libs/*.jar | head -1)
+echo -e "${GREEN}JAR file built: $JAR_FILE${NC}"
+
+# Build Docker image
+echo -e "${YELLOW}Building Docker image...${NC}"
+
+# If using Minikube, use its Docker daemon
+if command -v minikube &> /dev/null && minikube status | grep -q "Running"; then
+    echo -e "${YELLOW}Using Minikube's Docker daemon...${NC}"
+    eval $(minikube docker-env)
+fi
+
+# Build the image
+docker build -t solace-service:local -f kubernetes-pop-os/Dockerfile.local .
+
+echo -e "${GREEN}Docker image built successfully: solace-service:local${NC}"
+
+# Verify the image
+docker images | grep solace-service

--- a/kubernetes-pop-os/deploy-local.sh
+++ b/kubernetes-pop-os/deploy-local.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Set OS type to Linux for Pop OS
+OS_TYPE="Linux"
+
+SUDO_CMD="sudo"
+
+echo -e "${GREEN}Deploying Solace Service to local Kubernetes cluster on Pop OS Linux${NC}"
+
+# Check if kubectl is installed
+if ! command -v kubectl &> /dev/null; then
+    echo -e "${RED}kubectl is not installed. Please install it first.${NC}"
+    echo "Run: sudo apt install kubectl"
+    echo "Or follow: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/"
+    exit 1
+fi
+
+# Check for Kubernetes provider (minikube, microk8s, k3s, etc.)
+if command -v minikube &> /dev/null; then
+    echo -e "${GREEN}Minikube detected. Using Minikube for Kubernetes.${NC}"
+    KUBECTL_CMD="kubectl"
+    # Check if Minikube is running
+    if ! minikube status | grep -q "Running"; then
+        echo -e "${YELLOW}Minikube is not running. Starting Minikube...${NC}"
+        minikube start
+    fi
+    # Enable required addons
+    echo -e "${GREEN}Ensuring required Minikube addons are enabled...${NC}"
+    minikube addons enable storage-provisioner
+    minikube addons enable default-storageclass
+
+    # Set the environment to use minikube's Docker daemon
+    echo -e "${YELLOW}Setting up environment to use Minikube's Docker daemon...${NC}"
+    eval $(minikube docker-env)
+
+    # Set Minikube-specific variables
+    KUBE_PROVIDER="minikube"
+elif command -v microk8s &> /dev/null; then
+    echo -e "${GREEN}MicroK8s detected. Using MicroK8s for Kubernetes.${NC}"
+    KUBECTL_CMD="microk8s kubectl"
+    # Check if MicroK8s is running
+    if ! microk8s status | grep -q "microk8s is running"; then
+        echo -e "${YELLOW}MicroK8s is not running. Starting MicroK8s...${NC}"
+        $SUDO_CMD microk8s start
+    fi
+    # Enable required addons
+    echo -e "${GREEN}Ensuring required MicroK8s addons are enabled...${NC}"
+    $SUDO_CMD microk8s enable dns storage
+
+    # Set MicroK8s-specific variables
+    KUBE_PROVIDER="microk8s"
+elif command -v k3s &> /dev/null; then
+    echo -e "${GREEN}K3s detected. Using K3s for Kubernetes.${NC}"
+    KUBECTL_CMD="k3s kubectl"
+    # Check if K3s is running
+    if ! systemctl is-active --quiet k3s; then
+        echo -e "${YELLOW}K3s is not running. Starting K3s...${NC}"
+        $SUDO_CMD systemctl start k3s
+    fi
+
+    # Set K3s-specific variables
+    KUBE_PROVIDER="k3s"
+else
+    echo -e "${RED}No supported Kubernetes provider detected. Please install Minikube, MicroK8s, or K3s.${NC}"
+    echo "Run: sudo snap install microk8s --classic"
+    echo "Or visit: https://microk8s.io/docs/getting-started"
+    exit 1
+fi
+
+# Check kubectl version
+echo -e "${GREEN}Checking kubectl version...${NC}"
+$KUBECTL_CMD version --client
+
+# Navigate to the kubernetes-pop-os directory
+cd "$(dirname "$0")"
+
+echo -e "${YELLOW}Building Docker image...${NC}"
+./build-image.sh
+
+echo -e "${YELLOW}Applying Kubernetes manifests...${NC}"
+
+# Create namespace
+echo -e "${GREEN}Creating namespace...${NC}"
+$KUBECTL_CMD apply -f 00-namespace.yaml
+
+# Apply ConfigMap and Secrets
+echo -e "${GREEN}Creating ConfigMap and Secrets...${NC}"
+$KUBECTL_CMD apply -f 01-configmap.yaml
+$KUBECTL_CMD apply -f 02-secrets.yaml
+
+# Apply deployment
+echo -e "${GREEN}Deploying application...${NC}"
+$KUBECTL_CMD apply -f 03-deployment.yaml
+
+# Apply service
+echo -e "${GREEN}Creating service...${NC}"
+$KUBECTL_CMD apply -f 04-service.yaml
+
+# Wait for deployment to be ready
+echo -e "${YELLOW}Waiting for deployment to be ready...${NC}"
+$KUBECTL_CMD -n solace-service rollout status deployment/solace-service --timeout=300s
+
+# Get service information
+echo -e "${GREEN}Deployment completed successfully!${NC}"
+echo -e "${GREEN}Service information:${NC}"
+$KUBECTL_CMD -n solace-service get svc
+
+# Get NodePort
+NODE_PORT=$($KUBECTL_CMD get svc solace-service -n solace-service -o jsonpath='{.spec.ports[0].nodePort}')
+
+if [ -n "$NODE_PORT" ]; then
+    if [ "$KUBE_PROVIDER" = "minikube" ]; then
+        MINIKUBE_IP=$(minikube ip)
+        echo -e "${GREEN}Solace service is available at: http://${MINIKUBE_IP}:${NODE_PORT}${NC}"
+        echo -e "${GREEN}Or use port forwarding: minikube service solace-service -n solace-service${NC}"
+    else
+        echo -e "${GREEN}Solace service is available at: http://localhost:${NODE_PORT}${NC}"
+    fi
+else
+    echo -e "${YELLOW}NodePort not available. Use port forwarding:${NC}"
+    echo -e "${YELLOW}kubectl port-forward -n solace-service svc/solace-service 8080:8080${NC}"
+fi
+
+# Display pods
+echo -e "${GREEN}Pods:${NC}"
+$KUBECTL_CMD -n solace-service get pods -o wide
+
+echo -e "${GREEN}Deployment complete!${NC}"
+echo -e "${YELLOW}To view logs: kubectl logs -n solace-service -l app=solace-service -f${NC}"
+echo -e "${YELLOW}To test the service: curl http://localhost:${NODE_PORT}/actuator/health${NC}"


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for deploying the Solace Service to a local Kubernetes cluster on Pop OS (or similar Linux distributions) with automated CI/CD via GitHub Actions.

### What's New

- **Kubernetes Manifests** (`kubernetes-pop-os/`):
  - Complete deployment configuration for local K8s clusters
  - Support for Minikube, MicroK8s, and K3s
  - NodePort service for easy local access on port 30080
  - Proper health probes and resource limits

- **Deployment Scripts**:
  - `build-image.sh`: Builds Spring Boot app and Docker image
  - `deploy-local.sh`: Automated deployment with K8s provider detection
  - Comprehensive README with troubleshooting guides

- **GitHub Actions CI/CD**:
  - Automated deployment to self-hosted runner (`pop-os-1`)
  - Builds application with Gradle
  - Builds Docker image in Minikube's Docker daemon
  - Deploys with rolling updates
  - Includes health checks and verification

### Files Changed

- `.github/workflows/pop-os-1-deploy.yml` - GitHub Actions workflow
- `kubernetes-pop-os/` - Complete K8s deployment directory
  - Namespace, ConfigMap, Secrets, Deployment, Service manifests
  - Dockerfile, build and deployment scripts
  - Comprehensive README
- `README.md` - Updated with Pop OS deployment section

### Testing

To test locally:
```bash
cd kubernetes-pop-os
./deploy-local.sh
```

To test GitHub Actions:
- Set up self-hosted runner with `pop-os-1` label
- Push to main branch or manually trigger workflow

### References

This implementation is based on the successful deployment pattern from the randdai/rag-service project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)