### PR TITLE
Fix Docker build issues for Pop OS deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,10 +5,12 @@
 
 # Build artifacts
 build/
+!build/libs/*.jar
 target/
 .gradle/
 *.class
 *.jar
+!build/libs/*.jar
 *.war
 
 # IDE

--- a/kubernetes-pop-os/build-image.sh
+++ b/kubernetes-pop-os/build-image.sh
@@ -18,7 +18,8 @@ echo -e "${YELLOW}Building application with Gradle...${NC}"
 ./gradlew clean build -x test
 
 # Check if build was successful
-if [ ! -f build/libs/*.jar ]; then
+JAR_COUNT=$(ls build/libs/*.jar 2>/dev/null | wc -l)
+if [ "$JAR_COUNT" -eq 0 ]; then
     echo -e "${RED}Build failed - JAR file not found${NC}"
     exit 1
 fi
@@ -36,7 +37,7 @@ if command -v minikube &> /dev/null && minikube status | grep -q "Running"; then
     eval $(minikube docker-env)
 fi
 
-# Build the image
+# Build the image from project root with proper context
 docker build -t solace-service:local -f kubernetes-pop-os/Dockerfile.local .
 
 echo -e "${GREEN}Docker image built successfully: solace-service:local${NC}"


### PR DESCRIPTION
## Summary

This PR fixes Docker image build failures that occurred during local Kubernetes deployment on Pop OS.

## Problem

During deployment to pop-os-1, the Docker build step failed with:
```
ERROR: failed to solve: lstat /build/libs: no such file or directory
```

The build-image.sh script also had a bash syntax error when checking for JAR files.

## Root Cause

1. **`.dockerignore` issue**: The file was excluding the entire `build/` directory, preventing the `COPY build/libs/*.jar` command in the Dockerfile from finding the application JAR.

2. **Build script issue**: The `[ ! -f build/libs/*.jar ]` check doesn't work properly with wildcard paths in bash.

## Changes

### `.dockerignore`
- Added exception rules: `!build/libs/*.jar`
- Allows JAR files in `build/libs/` while still excluding other build artifacts
- Applied the exception twice to ensure it works with both the `build/` and `*.jar` exclusions

### `kubernetes-pop-os/build-image.sh`
- Replaced problematic `[ ! -f build/libs/*.jar ]` check
- Implemented proper JAR count validation:
  ```bash
  JAR_COUNT=$(ls build/libs/*.jar 2>/dev/null | wc -l)
  if [ "$JAR_COUNT" -eq 0 ]; then
  ```
- More robust error handling for missing JAR files
- Improved comment clarity

## Testing

Successfully deployed to Minikube on pop-os-1:
- ✅ Docker image builds successfully
- ✅ Pod status: Running
- ✅ Health check: UP
- ✅ Service accessible at: http://192.168.49.2:30080

```bash
# Deployment verification
kubectl get pods -n solace-service
# NAME                              READY   STATUS    RESTARTS   AGE
# solace-service-594dd679df-ctlvw   1/1     Running   0          108s

curl http://192.168.49.2:30080/actuator/health
# {"status":"UP",...}
```

## Impact

- Enables successful local Kubernetes deployments on Pop OS
- Fixes GitHub Actions workflow for pop-os-1 self-hosted runner
- No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)