### PR TITLE
Disable GitHub Actions workflow for pop-os-1 deployment

### DIFF
--- a/.github/workflows/pop-os-1-deploy.yml
+++ b/.github/workflows/pop-os-1-deploy.yml
@@ -1,45 +1,36 @@
-# This workflow will deploy the Solace Service to a self-hosted Kubernetes cluster on Pop OS
+# ⚠️ THIS WORKFLOW IS DISABLED ⚠️
 #
-# To configure this workflow:
+# This workflow is kept for reference but is disabled due to kubectl connectivity
+# issues between the GitHub Actions runner and Minikube on the shared cluster.
 #
-# 1. Set up a self-hosted GitHub runner on your Pop OS server
-#    - Follow instructions at: https://docs.github.com/en/actions/hosting-your-own-runners
-#    - Tag the runner with 'pop-os-1' label
+# RECOMMENDED APPROACH: Use manual deployment
+# cd kubernetes-pop-os && ./deploy-local.sh
 #
-# 2. Ensure the runner has access to:
-#    - Docker
-#    - kubectl
-#    - Java 21 (for building the application)
-#    - A running Kubernetes cluster (MicroK8s, K3s, or Minikube)
-#    - Proper permissions to create/modify resources in the cluster
+# See kubernetes-pop-os/README.md for complete instructions.
+#
+# ============================================================================
+# Original workflow configuration (for reference):
+# ============================================================================
+#
+# This workflow would deploy the Solace Service to a self-hosted Kubernetes
+# cluster on Pop OS, but kubectl commands timeout when run from the
+# github-runner user even with proper configuration.
+#
+# Manual deployment works perfectly and is safer for shared clusters with
+# production workloads (18+ pods from multiple applications).
 
-name: Deploy to Pop OS Kubernetes pop-os-1
+name: Deploy to Pop OS Kubernetes pop-os-1 (DISABLED)
 
 on:
-  push:
-    branches: ["main"]
-    paths:
-      - "src/**"
-      - "build.gradle"
-      - "kubernetes-pop-os/**"
-      - ".github/workflows/pop-os-1-deploy.yml"
+  # Disabled: workflow_dispatch only, no automatic triggers
   workflow_dispatch:
     inputs:
-      solace_enabled:
-        description: 'Enable Solace broker connection'
-        required: false
+      force_run:
+        description: 'This workflow is disabled. Use manual deployment instead.'
+        required: true
         default: 'false'
         type: choice
         options:
-          - 'true'
-          - 'false'
-      azure_storage_enabled:
-        description: 'Enable Azure Blob Storage'
-        required: false
-        default: 'false'
-        type: choice
-        options:
-          - 'true'
           - 'false'
 
 env:
@@ -49,9 +40,9 @@ env:
 
 jobs:
   deploy:
-    name: Deploy to Pop OS Kubernetes pop-os-1
-    # Ensure this job only runs on runners with the 'pop-os-1' label
-    # This ensures the workflow only runs on the designated Pop OS server
+    name: Deploy to Pop OS Kubernetes pop-os-1 (DISABLED)
+    # This workflow is disabled - see header comments for details
+    if: false  # Always skip this job
     runs-on: [self-hosted, pop-os-1]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -171,19 +171,18 @@ See [AKS Deployment Guide](AKS-DEPLOYMENT-GUIDE.md) for complete instructions.
 Deploy to a local Kubernetes cluster on Pop OS or similar Linux distributions:
 
 ```bash
-# Automated deployment
+# Manual deployment (recommended for pop-os-1)
 cd kubernetes-pop-os
 ./deploy-local.sh
-
-# Or use GitHub Actions for automated deployment to pop-os-1
-# Configure self-hosted runner with 'pop-os-1' label
 ```
 
 **Features:**
 - Automated local Kubernetes deployment
 - Support for Minikube, MicroK8s, and K3s
-- GitHub Actions integration for CI/CD
 - NodePort service for easy local access
+- Complete control and visibility
+
+**Note:** GitHub Actions workflow is disabled for pop-os-1 due to kubectl connectivity issues on shared clusters. Manual deployment is the recommended approach.
 
 See [kubernetes-pop-os/README.md](kubernetes-pop-os/README.md) for complete instructions.
 

--- a/kubernetes-pop-os/README.md
+++ b/kubernetes-pop-os/README.md
@@ -2,6 +2,17 @@
 
 This directory contains Kubernetes manifests and deployment scripts for running the Solace Service on a local Kubernetes cluster (Minikube, MicroK8s, or K3s) on Pop OS Linux.
 
+## ⚠️ GitHub Actions Workflow Status
+
+The GitHub Actions workflow (`.github/workflows/pop-os-1-deploy.yml`) is **DISABLED** and kept for reference only.
+
+**Why it's disabled:**
+- kubectl commands timeout when run from the github-runner user on shared Minikube clusters
+- Manual deployment is safer for shared clusters with production workloads (18+ pods)
+- Manual deployment gives better visibility and control
+
+**Recommended approach:** Use manual deployment (see below)
+
 ## Prerequisites
 
 1. **Kubernetes** - One of the following:
@@ -171,13 +182,27 @@ kubectl get events -n solace-service --sort-by='.lastTimestamp'
 - `build-image.sh`: Script to build Docker image
 - `deploy-local.sh`: Automated deployment script
 
-## GitHub Actions
+## GitHub Actions (Disabled)
 
-The service can be automatically deployed via GitHub Actions. See the workflow file at `.github/workflows/pop-os-1-deploy.yml`.
+⚠️ **The GitHub Actions workflow is disabled.** Use manual deployment instead.
 
-The workflow triggers on:
-- Push to `main` branch
-- Manual workflow dispatch
+The workflow file at `.github/workflows/pop-os-1-deploy.yml` is kept for reference but will not run automatically. It encountered kubectl connectivity issues between the GitHub Actions runner and Minikube on shared clusters.
+
+### Why Manual Deployment is Better for pop-os-1
+
+1. **Shared cluster safety**: pop-os-1 hosts 18+ pods from multiple applications (rag-service, solace-service)
+2. **Better control**: You can see exactly what's being deployed
+3. **Faster troubleshooting**: Direct access to logs and kubectl commands
+4. **No authentication issues**: Runs with your user credentials
+
+### Manual Deployment (Recommended)
+
+```bash
+cd kubernetes-pop-os
+./deploy-local.sh
+```
+
+This is the recommended and fully tested deployment method for pop-os-1.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
This PR disables the GitHub Actions workflow for pop-os-1 deployment but keeps it for reference. Manual deployment is now the recommended and documented approach.

## Why Disable the Workflow?
After extensive troubleshooting, we determined that:
- kubectl commands timeout when run from the github-runner user
- This occurs even with proper kubectl configuration and certificate permissions
- Commands work perfectly for the unidatum user but timeout for github-runner
- Manual deployment works flawlessly and is safer for the shared cluster

## What's Changed
- ✅ Workflow file kept for reference with DISABLED warnings
- ✅ Added `if: false` condition to prevent job execution
- ✅ Changed trigger to workflow_dispatch only (no automatic runs)
- ✅ Updated kubernetes-pop-os/README.md with workflow status
- ✅ Updated main README.md to recommend manual deployment
- ✅ Documented why manual deployment is better for pop-os-1

## Manual Deployment (Recommended)
```bash
cd kubernetes-pop-os
./deploy-local.sh
```

## Verification
Manual deployment tested and verified:
- ✅ Pod running: `solace-service-594dd679df-ctlvw` (1/1 Ready)
- ✅ Service exposed: NodePort 30080
- ✅ Health check: UP
- ✅ Accessible at: http://192.168.49.2:30080

## Benefits of Manual Deployment
1. **Shared cluster safety** - 18+ production pods remain unaffected
2. **Better control** - See exactly what's being deployed
3. **Faster troubleshooting** - Direct access to logs and kubectl
4. **No authentication issues** - Runs with your user credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)