### PR TITLE
Fix TransformationStorageIntegrationTest blob retrieval issue

### DIFF
--- a/src/test/java/com/example/solaceservice/integration/TransformationStorageIntegrationTest.java
+++ b/src/test/java/com/example/solaceservice/integration/TransformationStorageIntegrationTest.java
@@ -175,12 +175,8 @@ class TransformationStorageIntegrationTest {
 
         // Then - verify transformation record is stored
         BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient("solace-messages");
-        BlobClient transformationBlob = containerClient.listBlobs()
-                .stream()
-                .filter(blob -> blob.getName().startsWith("transformation-"))
-                .findFirst()
-                .map(blob -> containerClient.getBlobClient(blob.getName()))
-                .orElseThrow(() -> new AssertionError("Transformation blob not found"));
+        String transformationId = record.getTransformationId();
+        BlobClient transformationBlob = containerClient.getBlobClient("transformation-" + transformationId + ".json");
 
         // Download and parse transformation record
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();


### PR DESCRIPTION
## Summary

Fixed a test failure in `TransformationStorageIntegrationTest.testMT103ToMT202TransformationWithEncryptedStorage()` where the test was retrieving the wrong transformation blob from Azure Blob Storage.

## Problem

The test was using `findFirst()` to retrieve any blob starting with "transformation-", which could return a blob from a previous test execution instead of the current test's blob. This caused assertion failures when comparing correlation IDs:

```
expected: "test-transform-1761254372954"
 but was: "test-corr-123"
```

## Solution

Changed the blob retrieval logic to directly reference the specific blob by its transformation ID:

**Before:**
```java
BlobClient transformationBlob = containerClient.listBlobs()
    .stream()
    .filter(blob -> blob.getName().startsWith("transformation-"))
    .findFirst()
    .map(blob -> containerClient.getBlobClient(blob.getName()))
    .orElseThrow(() -> new AssertionError("Transformation blob not found"));
```

**After:**
```java
String transformationId = record.getTransformationId();
BlobClient transformationBlob = containerClient.getBlobClient("transformation-" + transformationId + ".json");
```

## Test Results

- ✅ All 139 tests now passing (was 137/139)
- ✅ 0 failures (was 2)
- ✅ TransformationStorageIntegrationTest: 6/6 tests passing
- ✅ SolaceAzureIntegrationTest: 8/8 tests passing

## Files Changed

- `src/test/java/com/example/solaceservice/integration/TransformationStorageIntegrationTest.java`

🤖 Generated with [Claude Code](https://claude.com/claude-code)