### PR TITLE
Build Azurite container from local Dockerfile in integration tests

### DIFF
--- a/src/test/java/com/example/solaceservice/integration/SolaceAzureIntegrationTest.java
+++ b/src/test/java/com/example/solaceservice/integration/SolaceAzureIntegrationTest.java
@@ -27,10 +27,12 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.web.client.RestTemplate;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -71,7 +73,9 @@ class SolaceAzureIntegrationTest {
                     .withStartupTimeout(java.time.Duration.ofSeconds(120)));
 
     @Container
-    static GenericContainer<?> azuriteContainer = new GenericContainer<>("mcr.microsoft.com/azure-storage/azurite:latest")
+    static GenericContainer<?> azuriteContainer = new GenericContainer<>(
+            new ImageFromDockerfile()
+                    .withDockerfile(Paths.get("Azurite-3.35.0/Dockerfile")))
             .withExposedPorts(10000, 10001, 10002)
             .withCommand("azurite", "--blobHost", "0.0.0.0", "--queueHost", "0.0.0.0", "--tableHost", "0.0.0.0", "--location", "/data")
             .waitingFor(Wait.forListeningPort()

--- a/src/test/java/com/example/solaceservice/integration/TransformationStorageIntegrationTest.java
+++ b/src/test/java/com/example/solaceservice/integration/TransformationStorageIntegrationTest.java
@@ -20,12 +20,14 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import java.io.ByteArrayOutputStream;
+import java.nio.file.Paths;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.UUID;
@@ -43,7 +45,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TransformationStorageIntegrationTest {
 
     @Container
-    static GenericContainer<?> azuriteContainer = new GenericContainer<>("mcr.microsoft.com/azure-storage/azurite:latest")
+    static GenericContainer<?> azuriteContainer = new GenericContainer<>(
+            new ImageFromDockerfile()
+                    .withDockerfile(Paths.get("Azurite-3.35.0/Dockerfile")))
             .withExposedPorts(10000, 10001, 10002)
             .withCommand("azurite", "--blobHost", "0.0.0.0", "--queueHost", "0.0.0.0", "--tableHost", "0.0.0.0", "--location", "/data")
             .waitingFor(Wait.forListeningPort()


### PR DESCRIPTION
## Summary

- Update integration tests to build Azurite container from local Dockerfile instead of pulling from Microsoft Container Registry
- Ensures consistency between docker-compose setup and test environment
- Eliminates internet dependency for running integration tests

## Changes

- **SolaceAzureIntegrationTest**: Use `ImageFromDockerfile` to build from `Azurite-3.35.0/Dockerfile`
- **TransformationStorageIntegrationTest**: Use `ImageFromDockerfile` to build from `Azurite-3.35.0/Dockerfile`
- Add required imports for `ImageFromDockerfile` and `Paths`

## Benefits

- ✅ No internet connection required to run tests
- ✅ Consistent Azurite version across all environments
- ✅ Faster test execution after initial build (image cached locally)
- ✅ Matches docker-compose.yml configuration

## Test Plan

- [x] Tests compile successfully (`./gradlew testClasses`)
- [ ] Integration tests pass with locally built Azurite container
- [ ] Verify Azurite image is built from local Dockerfile during test execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)