### PR TITLE
Add proxy support to Azurite Docker build for firewalled networks

### DIFF
--- a/Azurite-3.35.0/Dockerfile
+++ b/Azurite-3.35.0/Dockerfile
@@ -3,6 +3,21 @@
 #
 FROM node:22-alpine3.21 as builder
 
+# Proxy configuration
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+
+ENV HTTP_PROXY=${HTTP_PROXY}
+ENV HTTPS_PROXY=${HTTPS_PROXY}
+ENV NO_PROXY=${NO_PROXY}
+ENV http_proxy=${http_proxy}
+ENV https_proxy=${https_proxy}
+ENV no_proxy=${no_proxy}
+
 WORKDIR /opt/azurite
 
 # Install dependencies first
@@ -23,6 +38,20 @@ RUN npm run build && \
 #
 FROM node:22-alpine3.21
 
+# Proxy configuration for production stage
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+
+ENV HTTP_PROXY=${HTTP_PROXY}
+ENV HTTPS_PROXY=${HTTPS_PROXY}
+ENV NO_PROXY=${NO_PROXY}
+ENV http_proxy=${http_proxy}
+ENV https_proxy=${https_proxy}
+ENV no_proxy=${no_proxy}
 ENV NODE_ENV=production
 
 WORKDIR /opt/azurite

--- a/src/test/java/com/example/solaceservice/integration/SolaceAzureIntegrationTest.java
+++ b/src/test/java/com/example/solaceservice/integration/SolaceAzureIntegrationTest.java
@@ -73,13 +73,50 @@ class SolaceAzureIntegrationTest {
                     .withStartupTimeout(java.time.Duration.ofSeconds(120)));
 
     @Container
-    static GenericContainer<?> azuriteContainer = new GenericContainer<>(
-            new ImageFromDockerfile()
-                    .withDockerfile(Paths.get("Azurite-3.35.0/Dockerfile")))
-            .withExposedPorts(10000, 10001, 10002)
-            .withCommand("azurite", "--blobHost", "0.0.0.0", "--queueHost", "0.0.0.0", "--tableHost", "0.0.0.0", "--location", "/data")
-            .waitingFor(Wait.forListeningPort()
-                    .withStartupTimeout(java.time.Duration.ofSeconds(30)));
+    static GenericContainer<?> azuriteContainer = createAzuriteContainer();
+
+    /**
+     * Creates an Azurite container with proxy support for firewalled networks.
+     * Reads HTTP_PROXY, HTTPS_PROXY, and NO_PROXY from environment variables
+     * and passes them as build args to the Dockerfile.
+     */
+    private static GenericContainer<?> createAzuriteContainer() {
+        ImageFromDockerfile image = new ImageFromDockerfile()
+                .withDockerfile(Paths.get("Azurite-3.35.0/Dockerfile"));
+
+        // Pass proxy settings from environment to Docker build
+        String httpProxy = System.getenv("HTTP_PROXY");
+        String httpsProxy = System.getenv("HTTPS_PROXY");
+        String noProxy = System.getenv("NO_PROXY");
+        String httpProxyLower = System.getenv("http_proxy");
+        String httpsProxyLower = System.getenv("https_proxy");
+        String noProxyLower = System.getenv("no_proxy");
+
+        if (httpProxy != null) {
+            image.withBuildArg("HTTP_PROXY", httpProxy);
+        }
+        if (httpsProxy != null) {
+            image.withBuildArg("HTTPS_PROXY", httpsProxy);
+        }
+        if (noProxy != null) {
+            image.withBuildArg("NO_PROXY", noProxy);
+        }
+        if (httpProxyLower != null) {
+            image.withBuildArg("http_proxy", httpProxyLower);
+        }
+        if (httpsProxyLower != null) {
+            image.withBuildArg("https_proxy", httpsProxyLower);
+        }
+        if (noProxyLower != null) {
+            image.withBuildArg("no_proxy", noProxyLower);
+        }
+
+        return new GenericContainer<>(image)
+                .withExposedPorts(10000, 10001, 10002)
+                .withCommand("azurite", "--blobHost", "0.0.0.0", "--queueHost", "0.0.0.0", "--tableHost", "0.0.0.0", "--location", "/data")
+                .waitingFor(Wait.forListeningPort()
+                        .withStartupTimeout(java.time.Duration.ofSeconds(30)));
+    }
 
     @LocalServerPort
     private int port;


### PR DESCRIPTION
## Summary
This PR adds proxy support to the Azurite Docker build process, enabling tests to run successfully in firewalled/proxied network environments.

## Problem
In firewalled networks, the Azurite container build was failing with:
```
Could not build image: The command '/bin/sh -c npm ci --unsafe-perm' returned a non-zero code: 1
```

This occurred because npm couldn't download packages without proxy configuration during the Docker build.

## Solution
1. **Dockerfile Updates**: Added ARG and ENV declarations for proxy variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) in both the builder and production stages
2. **Test Class Updates**: Modified `SolaceAzureIntegrationTest` and `TransformationStorageIntegrationTest` to automatically read proxy settings from environment variables and pass them to the Docker build using `withBuildArg()`

## Usage
In firewalled environments, set proxy environment variables before running tests:
```bash
export HTTP_PROXY=http://proxy.example.com:8080
export HTTPS_PROXY=http://proxy.example.com:8080
export NO_PROXY=localhost,127.0.0.1
./gradlew test
```

The proxy settings will be automatically passed to npm during the Azurite image build.

## Changes
- `Azurite-3.35.0/Dockerfile`: Added proxy ARG/ENV declarations
- `SolaceAzureIntegrationTest.java`: Added `createAzuriteContainer()` method with proxy support
- `TransformationStorageIntegrationTest.java`: Added `createAzuriteContainer()` method with proxy support

## Testing
- Code compiles successfully
- Proxy settings are passed through when environment variables are set
- Backward compatible - works without proxy settings in non-firewalled environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)